### PR TITLE
Fix dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,3 @@
 (lang dune 3.0)
+(name ancient)
+(package (name ancient))


### PR DESCRIPTION
It seems that the name field is required, even if we don't use dune to generate opam files...