### PR TITLE
Remove opam template

### DIFF
--- a/ancient.opam.template
+++ b/ancient.opam.template
@@ -1,1 +1,0 @@
-available: os != "win32"


### PR DESCRIPTION
This file is not used as we no longer generate opam files with dune.