### PR TITLE
Prevent from running tests on 32bits systems

### DIFF
--- a/ancient.opam
+++ b/ancient.opam
@@ -35,7 +35,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & arch != "arm32" & arch != "x86_32"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
We don't plan to support these architectures and tests failed on opam-repository CI.