### PR TITLE
Support MSVC compiler on Windows

### DIFF
--- a/src/ancient_c.c
+++ b/src/ancient_c.c
@@ -26,7 +26,7 @@
 
 // Area is an expandable buffer, allocated on the C heap.
 typedef struct area {
-  void *ptr;			// Start of area.
+  char *ptr;			// Start of area.
   size_t n;			// Current position.
   size_t size;			// Allocated size.
 
@@ -205,7 +205,7 @@ _mark (value obj, area *ptr, area *restore, area *fixups)
 		    Field (obj_copy, i) =
 			    field_offset + sizeof (header_t);
 
-		    size_t fixup = (void *)&Field(obj_copy, i) - ptr->ptr;
+		    size_t fixup = (char *)&Field(obj_copy, i) - ptr->ptr;
 		    area_append (fixups, &fixup, sizeof fixup);
 	    }
     }

--- a/src/mmalloc/mmap-sup.c
+++ b/src/mmalloc/mmap-sup.c
@@ -216,7 +216,4 @@ mmalloc_findbase (size_t size)
   return ((PTR) base);
 }
 
-#else	/* defined(HAVE_MMAP) */
-/* Prevent "empty translation unit" warnings from the idiots at X3J11. */
-static char ansi_c_idiots __attribute__((unused)) = 69;
 #endif	/* defined(HAVE_MMAP) */


### PR DESCRIPTION
Get rid of void pointer arithmetic and gcc attribute syntax