### PR TITLE
Use flake-parts and expose a proper overlay

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake
+use flake . -L

--- a/ancient.opam
+++ b/ancient.opam
@@ -26,7 +26,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,30 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764020296,
-        "narHash": "sha256-6zddwDs2n+n01l+1TG6PlyokDdXzu/oBmEejcH5L5+A=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a320ce8e6e2cc6b4397eef214d202a50a4583829",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {
@@ -34,25 +34,38 @@
         "type": "github"
       }
     },
-    "root": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
+      }
+    },
+    "ocaml-debug-info-overlay": {
+      "locked": {
+        "lastModified": 1779987804,
+        "narHash": "sha256-qXtRVEYeF0bA/RBTyxaY8Klyf7l3LC+gjqmoKS89CGY=",
+        "path": "/home/tiky/projects/ocaml-debug-info-overlay",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/tiky/projects/ocaml-debug-info-overlay",
+        "type": "path"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "ocaml-debug-info-overlay": "ocaml-debug-info-overlay"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,39 +1,71 @@
 {
-  description = "Ancient library";
+  description = "The Ancient library";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    ocaml-debug-info-overlay.url = "path:/home/tiky/projects/ocaml-debug-info-overlay";
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      flake-utils,
-      ...
-    }@inputs:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
-        formatter = pkgs.nixfmt;
+    { self, nixpkgs, ... }@inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
 
-        packages.default = pkgs.ocamlPackages.callPackage ./nix/ancient.nix { };
+      perSystem =
+        { system, pkgs, ... }:
+        {
+          _module.args.pkgs = import self.inputs.nixpkgs {
+            inherit system;
+            overlays = [ (import ./nix/overlays/ocaml-nnp.nix) ];
+          };
 
-        overlays.default = super: self: {
-          ocamlPackages = self.ocamlPackages.overrideScope (
-            final: prev: {
-              ocamlPackages.ancient = final.callPackage ./nix/ancient.nix { };
-            }
-          );
+          formatter = pkgs.nixfmt-tree;
+
+          packages.default = pkgs.ocamlPackages.callPackage ./nix/ancient.nix { };
+
+          devShells =
+            let
+              mkShell =
+                {
+                  version ? "5_3",
+                  debug ? false,
+                }:
+                let
+                  devPkgs =
+                    let
+                      debug-overlay = inputs.ocaml-debug-info-overlay.overlays.default;
+                    in
+                    if debug then pkgs.extend debug-overlay else pkgs;
+                  ocamlPackages = devPkgs.ocaml-ng."ocamlPackages_${version}";
+                in
+                devPkgs.mkShell {
+                  packages = with ocamlPackages; [
+                    odoc
+                    ocaml-lsp
+                    dune-release
+                    ocamlformat
+                  ];
+
+                  inputsFrom = [ (ocamlPackages.callPackage ./nix/ancient.nix { }) ];
+                };
+            in
+            {
+              default = mkShell { };
+              ocaml4 = mkShell { version = "4_14"; };
+              debug = mkShell { debug = true; };
+            };
         };
 
-        devShells.default = pkgs.callPackage ./nix/devshell.nix {
-          enableDebug = true;
-        };
-      }
-    );
+      flake.overlays = {
+        default = nixpkgs.lib.fixedPoints.composeManyExtensions [
+          (import ./nix/overlays/ocaml-nnp.nix)
+          (import ./nix/overlays/ancient.nix)
+        ];
+      };
+    };
 }

--- a/nix/ancient.nix
+++ b/nix/ancient.nix
@@ -1,16 +1,18 @@
 {
-  buildDunePackage,
   lib,
+  buildDunePackage,
 }:
 
 buildDunePackage {
   pname = "ancient";
   version = "dev";
-  src = ../.;
+  src = lib.cleanSource ../.;
+
+  doCheck = true;
 
   meta = {
     description = "Ancient library";
     homepage = "https://github.com/OCamlPro/ocaml-ancient";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.lgpl21Plus;
   };
 }

--- a/nix/overlays/ancient.nix
+++ b/nix/overlays/ancient.nix
@@ -1,0 +1,22 @@
+self: super:
+let
+  mkOverride =
+    ocamlPackages:
+    ocamlPackages.overrideScope (
+      final: prev: {
+        ancient = final.callPackage ./ancient.nix { };
+      }
+    );
+in
+{
+  ocamlPackages = mkOverride super.ocamlPackages;
+
+  ocaml-ng = super.ocaml-ng // {
+    ocamlPackages_4_14 = mkOverride super.ocaml-ng.ocamlPackages_4_14;
+    ocamlPackages_5_0 = mkOverride super.ocaml-ng.ocamlPackages_5_0;
+    ocamlPackages_5_1 = mkOverride super.ocaml-ng.ocamlPackages_5_1;
+    ocamlPackages_5_2 = mkOverride super.ocaml-ng.ocamlPackages_5_2;
+    ocamlPackages_5_3 = mkOverride super.ocaml-ng.ocamlPackages_5_3;
+    ocamlPackages_5_4 = mkOverride super.ocaml-ng.ocamlPackages_5_4;
+  };
+}

--- a/nix/overlays/ocaml-nnp.nix
+++ b/nix/overlays/ocaml-nnp.nix
@@ -1,0 +1,22 @@
+self: super:
+let
+  mkOverride =
+    ocamlPackages:
+    ocamlPackages.overrideScope (
+      final: prev: {
+        ocaml = prev.ocaml.override { noNakedPointers = prev.ocaml.version == "4.14.2"; };
+      }
+    );
+in
+{
+  ocamlPackages = mkOverride super.ocamlPackages;
+
+  ocaml-ng = super.ocaml-ng // {
+    ocamlPackages_4_14 = mkOverride super.ocaml-ng.ocamlPackages_4_14;
+    ocamlPackages_5_0 = mkOverride super.ocaml-ng.ocamlPackages_5_0;
+    ocamlPackages_5_1 = mkOverride super.ocaml-ng.ocamlPackages_5_1;
+    ocamlPackages_5_2 = mkOverride super.ocaml-ng.ocamlPackages_5_2;
+    ocamlPackages_5_3 = mkOverride super.ocaml-ng.ocamlPackages_5_3;
+    ocamlPackages_5_4 = mkOverride super.ocaml-ng.ocamlPackages_5_4;
+  };
+}


### PR DESCRIPTION
The previous flake version was complicated because of code to handle debug info symbols for OCaml runtime. This code has been moved to a separated flake.

Changes:
- Expose a proper overlay with noNakedPointer for OCaml 4.
- Replace deprecated nixpkgs-fmt by nixfmt-tree formatter,
- Replace unmaintened flake-utils by flake-parts,
- Use lib.cleanSource to remove .git directory and prevent Dune from calling git,
- Remove `dune subst` in the opam file as we don't need to update version in sources.